### PR TITLE
Update to use configs route for email links

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var nodemailer = require('nodemailer');
 var ejs = require('ejs');
 
@@ -34,9 +33,9 @@ module.exports = function(config) {
 
     // link lookup map
     var linkMap = {
-      emailSignup: '<a href="' + config.url + config.signupRoute + '/' + token + '">' + config.emailSignup.linkText + '</a>',
-      emailResendVerification: '<a href="' + config.url + config.signupRoute + '/' + token + '">' + config.emailResendVerification.linkText + '</a>',
-      emailForgotPassword: '<a href="' + config.url + config.forgotPasswordRoute + '/' + token + '">' + config.emailForgotPassword.linkText + '</a>'
+      emailSignup: '<a href="' + config.url + config.signup.route + '/' + token + '">' + config.emailSignup.linkText + '</a>',
+      emailResendVerification: '<a href="' + config.url + config.signup.route + '/' + token + '">' + config.emailResendVerification.linkText + '</a>',
+      emailForgotPassword: '<a href="' + config.url + config.forgotPassword.route + '/' + token + '">' + config.emailForgotPassword.linkText + '</a>'
     };
             
     // get subject, title and text from config file


### PR DESCRIPTION
The 'signupRoute' does not exist in the default config and resulted in undefined in my link, and it makes sense to use the same link that will be caught by the routes setup in the other modules.
Could also be worth using path.join to ensure slashes are correct.
